### PR TITLE
Implement task CRUD

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -25,7 +25,9 @@ class TaskController extends Controller
      */
     public function create()
     {
-        //
+        return view('tasks.create', [
+            'task' => new Task(),
+        ]);
     }
 
     /**
@@ -51,7 +53,9 @@ class TaskController extends Controller
      */
     public function show(Task $task)
     {
-        //
+        $this->authorizeTask($task);
+
+        return view('tasks.show', compact('task'));
     }
 
     /**
@@ -59,7 +63,9 @@ class TaskController extends Controller
      */
     public function edit(Task $task)
     {
-        //
+        $this->authorizeTask($task);
+
+        return view('tasks.edit', compact('task'));
     }
 
     /**
@@ -67,7 +73,19 @@ class TaskController extends Controller
      */
     public function update(Request $request, Task $task)
     {
-        //
+        $this->authorizeTask($task);
+
+        $data = $request->validate([
+            'title'       => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'due_date'    => 'nullable|date',
+            'status'      => 'required|in:pending,in_progress,completed',
+        ]);
+
+        $task->update($data);
+
+        return redirect()->route('tasks.index')
+            ->with('success', 'Task updated!');
     }
 
     /**
@@ -75,6 +93,16 @@ class TaskController extends Controller
      */
     public function destroy(Task $task)
     {
-        //
+        $this->authorizeTask($task);
+
+        $task->delete();
+
+        return redirect()->route('tasks.index')
+            ->with('success', 'Task deleted!');
+    }
+
+    private function authorizeTask(Task $task): void
+    {
+        abort_unless($task->user_id === auth()->id(), 403);
     }
 }

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Task>
+ */
+class TaskFactory extends Factory
+{
+    protected $model = Task::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'title' => $this->faker->sentence(3),
+            'description' => $this->faker->optional()->paragraph(),
+            'due_date' => $this->faker->optional()->date(),
+            'status' => $this->faker->randomElement(['pending', 'in_progress', 'completed']),
+        ];
+    }
+}

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -1,0 +1,21 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Create Task') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                <div class="max-w-xl">
+                    @include('tasks.partials.form', [
+                        'task' => $task,
+                        'action' => route('tasks.store'),
+                        'submit' => 'Create',
+                    ])
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -1,0 +1,22 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Task') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                <div class="max-w-xl">
+                    @include('tasks.partials.form', [
+                        'task' => $task,
+                        'action' => route('tasks.update', $task),
+                        'method' => 'PUT',
+                        'submit' => 'Update',
+                    ])
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tasks/partials/form.blade.php
+++ b/resources/views/tasks/partials/form.blade.php
@@ -1,0 +1,38 @@
+@props(['task', 'method' => 'POST', 'action', 'submit'])
+
+<form method="POST" action="{{ $action }}" class="space-y-4">
+    @csrf
+    @if(!in_array(strtoupper($method), ['POST', 'GET']))
+        @method($method)
+    @endif
+
+    <div>
+        <x-input-label for="title" :value="__('Title')" />
+        <x-text-input id="title" name="title" type="text" class="mt-1 block w-full" :value="old('title', $task->title)" required />
+        <x-input-error class="mt-2" :messages="$errors->get('title')" />
+    </div>
+
+    <div>
+        <x-input-label for="description" :value="__('Description')" />
+        <textarea id="description" name="description" rows="3" class="mt-1 block w-full border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm">{{ old('description', $task->description) }}</textarea>
+        <x-input-error class="mt-2" :messages="$errors->get('description')" />
+    </div>
+
+    <div>
+        <x-input-label for="due_date" :value="__('Due Date')" />
+        <x-text-input id="due_date" name="due_date" type="date" class="mt-1 block w-full" :value="old('due_date', optional($task->due_date)->format('Y-m-d'))" />
+        <x-input-error class="mt-2" :messages="$errors->get('due_date')" />
+    </div>
+
+    <div>
+        <x-input-label for="status" :value="__('Status')" />
+        <select id="status" name="status" class="mt-1 block w-full border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm">
+            @foreach(['pending' => 'Pending', 'in_progress' => 'In Progress', 'completed' => 'Completed'] as $value => $label)
+                <option value="{{ $value }}" @selected(old('status', $task->status) === $value)>{{ $label }}</option>
+            @endforeach
+        </select>
+        <x-input-error class="mt-2" :messages="$errors->get('status')" />
+    </div>
+
+    <x-primary-button>{{ $submit }}</x-primary-button>
+</form>

--- a/resources/views/tasks/show.blade.php
+++ b/resources/views/tasks/show.blade.php
@@ -1,0 +1,21 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Task Details') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white shadow sm:rounded-lg p-4">
+                <h1 class="text-lg font-medium">{{ $task->title }}</h1>
+                <p class="mt-2">{{ $task->description }}</p>
+                <p class="mt-2">Due: {{ $task->due_date?->format('M d, Y') ?? '—' }}</p>
+                <p class="mt-2">Status: {{ ucfirst($task->status) }}</p>
+                <div class="mt-4">
+                    <a href="{{ route('tasks.edit', $task) }}" class="text-indigo-500">Edit</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Models\Task;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -29,5 +30,54 @@ class TaskTest extends TestCase
             'user_id' => $user->id,
             'title' => 'Test Task',
         ]);
+    }
+
+    public function test_authenticated_user_can_update_task(): void
+    {
+        $user = User::factory()->create();
+        $task = Task::factory()->for($user)->create(['title' => 'Old Title']);
+
+        $response = $this->actingAs($user)->put("/tasks/{$task->id}", [
+            'title' => 'Updated Title',
+            'description' => $task->description,
+            'due_date' => $task->due_date?->format('Y-m-d'),
+            'status' => 'completed',
+        ]);
+
+        $response->assertRedirect(route('tasks.index'));
+
+        $this->assertDatabaseHas('tasks', [
+            'id' => $task->id,
+            'title' => 'Updated Title',
+            'status' => 'completed',
+        ]);
+    }
+
+    public function test_authenticated_user_can_delete_task(): void
+    {
+        $user = User::factory()->create();
+        $task = Task::factory()->for($user)->create();
+
+        $response = $this->actingAs($user)->delete("/tasks/{$task->id}");
+
+        $response->assertRedirect(route('tasks.index'));
+
+        $this->assertDatabaseMissing('tasks', [
+            'id' => $task->id,
+        ]);
+    }
+
+    public function test_user_cannot_modify_other_users_task(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $task = Task::factory()->for($other)->create();
+
+        $response = $this->actingAs($user)->put("/tasks/{$task->id}", [
+            'title' => 'Fail',
+            'status' => 'pending',
+        ]);
+
+        $response->assertStatus(403);
     }
 }


### PR DESCRIPTION
## Summary
- implement create/edit/show/destroy logic in `TaskController`
- add shared form partial and create/edit/show views
- provide `TaskFactory` for test data
- extend task feature tests for update/delete and access control

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6868b6931fa88331ac525bb75a575bc6